### PR TITLE
Add DOCX to PDF conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,20 @@ See `go help install` for details on the installation location of the installed 
 - wv
 - popplerutils
 - unrtf
+- libreoffice (or unoconv)
 - https://github.com/JalfResi/justext
 
 ### Debian-based Linux
 
 ```console
-$ sudo apt-get install poppler-utils wv unrtf tidy
+$ sudo apt-get install poppler-utils wv unrtf tidy libreoffice
 $ go get github.com/JalfResi/justext
 ```
 
 ### macOS
 
 ```console
-$ brew install poppler-qt5 wv unrtf tidy-html5
+$ brew install poppler-qt5 wv unrtf tidy-html5 libreoffice
 $ go get github.com/JalfResi/justext
 ```
 
@@ -158,4 +159,26 @@ Alternatively, via a `curl`:
 
 ```console
 $ curl -s -F input=@your-file.pdf http://localhost:8888/convert
+```
+
+### Convert DOCX to PDF
+
+If libreoffice is installed you can convert a DOCX file to a PDF using the helper function:
+
+```go
+package main
+
+import (
+        "fmt"
+
+        "code.sajari.com/docconv/v2"
+)
+
+func main() {
+        pdfPath, err := docconv.ConvertDocxToPDF("document.docx", "/tmp")
+        if err != nil {
+                // TODO: handle
+        }
+        fmt.Println("PDF written to", pdfPath)
+}
 ```

--- a/docd/main.go
+++ b/docd/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"cloud.google.com/go/compute/metadata"
@@ -23,7 +24,8 @@ import (
 var (
 	listenAddr = flag.String("addr", ":8888", "The address to listen on (e.g. 127.0.0.1:8888)")
 
-	inputPath = flag.String("input", "", "The file path to convert and exit; no server")
+	inputPath    = flag.String("input", "", "The file path to convert and exit; no server")
+	docx2pdfPath = flag.String("docx2pdf", "", "Convert a DOCX to PDF and exit")
 
 	jsonCloudLogging = flag.Bool("json-cloud-logging", false, "Whether or not to enable JSON Cloud Logging")
 
@@ -102,6 +104,16 @@ func main() {
 		MaxLinkDensity:        *readabilityMaxLinkDensity,
 		MaxHeadingDistance:    *readabilityMaxHeadingDistance,
 		ReadabilityUseClasses: *readabilityUseClasses,
+	}
+
+	if *docx2pdfPath != "" {
+		pdfPath, err := docconv.ConvertDocxToPDF(*docx2pdfPath, filepath.Dir(*docx2pdfPath))
+		if err != nil {
+			l.Error("Could not convert DOCX to PDF", "error", err, "path", *docx2pdfPath)
+			os.Exit(1)
+		}
+		fmt.Print(pdfPath)
+		return
 	}
 
 	if *inputPath != "" {

--- a/docx_pdf.go
+++ b/docx_pdf.go
@@ -1,0 +1,21 @@
+package docconv
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ConvertDocxToPDF converts a DOCX file at path to a PDF inside outDir using libreoffice.
+// It returns the path to the generated PDF file.
+func ConvertDocxToPDF(path string, outDir string) (string, error) {
+	cmd := exec.Command("libreoffice", "--headless", "--convert-to", "pdf", path, "--outdir", outDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("libreoffice convert: %v, output: %s", err, out)
+	}
+	base := filepath.Base(path)
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	pdfPath := filepath.Join(outDir, base+".pdf")
+	return pdfPath, nil
+}

--- a/docx_test/docx_pdf_test.go
+++ b/docx_test/docx_pdf_test.go
@@ -1,0 +1,20 @@
+package docx_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"code.sajari.com/docconv/v2"
+)
+
+func TestConvertDocxToPDF(t *testing.T) {
+	tmpDir := t.TempDir()
+	pdfPath, err := docconv.ConvertDocxToPDF(filepath.Join("./testdata", "sample.docx"), tmpDir)
+	if err != nil {
+		t.Fatalf("got error = %v, want nil", err)
+	}
+	if _, err := os.Stat(pdfPath); err != nil {
+		t.Fatalf("expected output %s to exist: %v", pdfPath, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `ConvertDocxToPDF` for converting DOCX files with libreoffice
- support `-docx2pdf` command line option in `docd`
- test DOCX to PDF conversion
- document libreoffice dependency and example usage

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840852215b08331be12a49e69608c1b