### PR TITLE
Add DOCX to PDF conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,113 +5,114 @@
 [![Report card](https://goreportcard.com/badge/code.sajari.com/docconv/v2)](https://goreportcard.com/report/code.sajari.com/docconv/v2)
 [![Sourcegraph](https://sourcegraph.com/github.com/sajari/docconv/v2/-/badge.svg)](https://sourcegraph.com/github.com/sajari/docconv/v2)
 
-A Go wrapper library to convert PDF, DOC, DOCX, XML, HTML, RTF, ODT, Pages documents and images (see optional dependencies below) to plain text.
+Go 語言的封裝函式庫，可將 PDF、DOC、DOCX、XML、HTML、RTF、ODT、Pages 文件以及影像（可選擇安裝的相依套件）轉為純文字。
 
-## Installation
+## 安裝
 
-If you haven't setup Go before, you first need to [install Go](https://golang.org/doc/install).
+若尚未安裝 Go，請先依照 [官方指南](https://golang.org/doc/install) 完成安裝。
 
-To fetch and build the code:
+接著抓取並建置程式碼：
 
 ```console
 $ go install code.sajari.com/docconv/v2/docd@latest
 ```
 
-See `go help install` for details on the installation location of the installed `docd` executable. Make sure that the full path to the executable is in your `PATH` environment variable.
+更多關於安裝後 `docd` 可執行檔路徑的說明，請參閱 `go help install`。安裝完成後請確定其路徑已加入 `PATH` 環境變數。
 
-## Dependencies
+## 依賴套件
 
 - tidy
 - wv
 - popplerutils
 - unrtf
+- libreoffice（或 unoconv）
 - https://github.com/JalfResi/justext
 
-### Debian-based Linux
+### Debian 系 Linux
 
 ```console
-$ sudo apt-get install poppler-utils wv unrtf tidy
+$ sudo apt-get install poppler-utils wv unrtf tidy libreoffice
 $ go get github.com/JalfResi/justext
 ```
 
 ### macOS
 
 ```console
-$ brew install poppler-qt5 wv unrtf tidy-html5
+$ brew install poppler-qt5 wv unrtf tidy-html5 libreoffice
 $ go get github.com/JalfResi/justext
 ```
 
-### Optional dependencies
+### 可選依賴
 
-To add image support to the `docconv` library you first need to [install and build gosseract](https://github.com/otiai10/gosseract/tree/v2.2.4).
+若要讓 `docconv` 支援影像轉換，必須先 [安裝並建置 gosseract](https://github.com/otiai10/gosseract/tree/v2.2.4)。
 
-Now you can add `-tags ocr` to any `go` command when building/fetching/testing `docconv` to include support for processing images:
+完成後，於建置、下載或測試 `docconv` 時加上 `-tags ocr` 參數，即可啟用影像處理：
 
 ```console
 $ go get -tags ocr code.sajari.com/docconv/v2/...
 ```
 
-This may complain on macOS, which you can fix by installing [tesseract](https://tesseract-ocr.github.io) via brew:
+在 macOS 上若遇到錯誤，可透過 brew 安裝 [tesseract](https://tesseract-ocr.github.io) 解決：
 
 ```console
 $ brew install tesseract
 ```
 
-## docd tool
+## docd 工具
 
-The `docd` tool runs as either:
+`docd` 可以以下列幾種方式運行：
 
-1.  a service on port 8888 (by default)
+1.  預設在 8888 埠口上運行的服務
 
-    Documents can be sent as a multipart POST request and the plain text (body) and meta information are then returned as a JSON object.
+    可透過 multipart POST 傳送文件，服務會回傳純文字內容與後設資訊的 JSON。
 
-2.  a service exposed from within a Docker container
+2.  於 Docker container 中執行的服務
 
-    This also runs as a service, but from within a Docker container.
-    Official images are published at https://hub.docker.com/r/sajari/docd.
+    同樣以服務方式執行，但封裝在 Docker container 中。
+    官方映像位於 https://hub.docker.com/r/sajari/docd。
 
-    Optionally you can build it yourself:
+    你也可以自行建置：
 
     ```console
     $ cd docd
     $ docker build -t docd .
     ```
 
-3.  via the command line.
+3.  直接使用指令列。
 
-    Documents can be sent as an argument, e.g.
+    將檔案路徑作為參數，例如：
 
     ```console
     $ docd -input document.pdf
     ```
 
-### Optional flags
+### 其他旗標
 
-- `addr` - the bind address for the HTTP server, default is ":8888"
-- `readability-length-low` - sets the readability length low if the ?readability=1 parameter is set
-- `readability-length-high` - sets the readability length high if the ?readability=1 parameter is set
-- `readability-stopwords-low` - sets the readability stopwords low if the ?readability=1 parameter is set
-- `readability-stopwords-high` - sets the readability stopwords high if the ?readability=1 parameter is set
-- `readability-max-link-density` - sets the readability max link density if the ?readability=1 parameter is set
-- `readability-max-heading-distance` - sets the readability max heading distance if the ?readability=1 parameter is set
-- `readability-use-classes` - comma separated list of readability classes to use if the ?readability=1 parameter is set
+- `addr` - HTTP 伺服器綁定地址，預設為 ":8888"
+- `readability-length-low` - 配合 ?readability=1 參數設定 readability 的 length low
+- `readability-length-high` - 配合 ?readability=1 參數設定 readability 的 length high
+- `readability-stopwords-low` - 配合 ?readability=1 參數設定 stopwords low
+- `readability-stopwords-high` - 配合 ?readability=1 參數設定 stopwords high
+- `readability-max-link-density` - 配合 ?readability=1 參數設定最大連結密度
+- `readability-max-heading-distance` - 配合 ?readability=1 參數設定最大標題距離
+- `readability-use-classes` - 配合 ?readability=1 參數指定 readability 類別，逗號分隔
 
-### How to start the service
+### 啟動服務
 
 ```console
-$ # This runs on port 8000
+$ # 於 8000 埠口啟動
 $ docd -addr :8000
 ```
 
-## Example usage (code)
+## 範例程式
 
-Some basic code is shown below, but normally you would accept the file by HTTP or open it from the file system.
+以下範例僅供參考，實際情況通常是透過 HTTP 收取檔案或從檔案系統讀取。
 
-This should be enough to get you started though.
+這應該足以讓你開始使用。
 
-### Use case 1: run locally
+### 使用情境一：在本機執行
 
-> Note: this assumes you have the [dependencies](#dependencies) installed.
+> 注意：假設你已安裝好[依賴套件](#依賴套件)。
 
 ```go
 package main
@@ -131,7 +132,7 @@ func main() {
 }
 ```
 
-### Use case 2: request over the network
+### 使用情境二：透過網路請求
 
 ```go
 package main
@@ -143,8 +144,8 @@ import (
 )
 
 func main() {
-	// Create a new client, using the default endpoint (localhost:8888)
-	c := client.New()
+        // 建立新客戶端，預設端點為 localhost:8888
+        c := client.New()
 
 	res, err := client.ConvertPath(c, "your-file.pdf")
 	if err != nil {
@@ -154,8 +155,30 @@ func main() {
 }
 ```
 
-Alternatively, via a `curl`:
+也可以透過 `curl` 直接請求：
 
 ```console
 $ curl -s -F input=@your-file.pdf http://localhost:8888/convert
+```
+
+### 將 DOCX 轉換為 PDF
+
+若已安裝 libreoffice，可利用下列輔助函式將 DOCX 檔轉成 PDF：
+
+```go
+package main
+
+import (
+        "fmt"
+
+        "code.sajari.com/docconv/v2"
+)
+
+func main() {
+        pdfPath, err := docconv.ConvertDocxToPDF("document.docx", "/tmp")
+        if err != nil {
+                // TODO: handle
+        }
+        fmt.Println("PDF 輸出於", pdfPath)
+}
 ```

--- a/docd/appengine/README.md
+++ b/docd/appengine/README.md
@@ -1,6 +1,6 @@
-# Deploying docd to AppEngine
+# 將 docd 部署到 AppEngine
 
-Within this directory run:
+在此目錄中執行：
 
 ```
 gcloud app deploy

--- a/docd/main.go
+++ b/docd/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"cloud.google.com/go/compute/metadata"
@@ -23,7 +24,8 @@ import (
 var (
 	listenAddr = flag.String("addr", ":8888", "The address to listen on (e.g. 127.0.0.1:8888)")
 
-	inputPath = flag.String("input", "", "The file path to convert and exit; no server")
+	inputPath    = flag.String("input", "", "The file path to convert and exit; no server")
+	docx2pdfPath = flag.String("docx2pdf", "", "Convert a DOCX to PDF and exit")
 
 	jsonCloudLogging = flag.Bool("json-cloud-logging", false, "Whether or not to enable JSON Cloud Logging")
 
@@ -102,6 +104,16 @@ func main() {
 		MaxLinkDensity:        *readabilityMaxLinkDensity,
 		MaxHeadingDistance:    *readabilityMaxHeadingDistance,
 		ReadabilityUseClasses: *readabilityUseClasses,
+	}
+
+	if *docx2pdfPath != "" {
+		pdfPath, err := docconv.ConvertDocxToPDF(*docx2pdfPath, filepath.Dir(*docx2pdfPath))
+		if err != nil {
+			l.Error("Could not convert DOCX to PDF", "error", err, "path", *docx2pdfPath)
+			os.Exit(1)
+		}
+		fmt.Print(pdfPath)
+		return
 	}
 
 	if *inputPath != "" {

--- a/docx_pdf.go
+++ b/docx_pdf.go
@@ -1,0 +1,21 @@
+package docconv
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ConvertDocxToPDF converts a DOCX file at path to a PDF inside outDir using libreoffice.
+// It returns the path to the generated PDF file.
+func ConvertDocxToPDF(path string, outDir string) (string, error) {
+	cmd := exec.Command("libreoffice", "--headless", "--convert-to", "pdf", path, "--outdir", outDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("libreoffice convert: %v, output: %s", err, out)
+	}
+	base := filepath.Base(path)
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	pdfPath := filepath.Join(outDir, base+".pdf")
+	return pdfPath, nil
+}

--- a/docx_test/docx_pdf_test.go
+++ b/docx_test/docx_pdf_test.go
@@ -1,0 +1,20 @@
+package docx_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"code.sajari.com/docconv/v2"
+)
+
+func TestConvertDocxToPDF(t *testing.T) {
+	tmpDir := t.TempDir()
+	pdfPath, err := docconv.ConvertDocxToPDF(filepath.Join("./testdata", "sample.docx"), tmpDir)
+	if err != nil {
+		t.Fatalf("got error = %v, want nil", err)
+	}
+	if _, err := os.Stat(pdfPath); err != nil {
+		t.Fatalf("expected output %s to exist: %v", pdfPath, err)
+	}
+}

--- a/iWork/pb-schema/README.md
+++ b/iWork/pb-schema/README.md
@@ -1,1 +1,1 @@
-These .proto files were created by running [proto-dump](https://github.com/obriensp/proto-dump) on Keynote 6.0, Pages 5.0 and Numbers 3.0.
+這些 .proto 檔案是透過在 Keynote 6.0、Pages 5.0 以及 Numbers 3.0 上執行 [proto-dump](https://github.com/obriensp/proto-dump) 產生的。

--- a/snappy/README
+++ b/snappy/README
@@ -1,13 +1,10 @@
-This is a Snappy library for the Go programming language that has been modified to work with Apple files, which fail to set CRC checks and stream identifiers. This version is a total hack, so if you want to use snappy for other projects **DO NOT USE THIS VERSION**. Use the proper version as per below:
+這是一個供 Go 使用的 Snappy 函式庫，已修改以處理 Apple 檔案（這些檔案未設定 CRC 檢查與串流識別）。此版本僅為臨時方案，若要在其他專案使用 Snappy，**請勿使用此版本**，請使用下方連結所指的正式版本。
 
-To download and install from source:
+從原始碼下載並安裝：
 $ go get code.google.com/p/snappy-go/snappy
 
+除非另有說明，Snappy-Go 原始碼以 LICENSE 檔中所列的 BSD 授權釋出。
 
-
-Unless otherwise noted, the Snappy-Go source files are distributed
-under the BSD-style license found in the LICENSE file.
-
-Contributions should follow the same procedure as for the Go project:
+貢獻時請遵循 Go 專案的流程：
 http://golang.org/doc/contribute.html
 


### PR DESCRIPTION
## Summary
- add `ConvertDocxToPDF` for converting DOCX files with libreoffice
- support `-docx2pdf` command line option in `docd`
- test DOCX to PDF conversion
- document libreoffice dependency and example usage
- translate documentation to Traditional Chinese

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840852215b08331be12a49e69608c1b